### PR TITLE
Fix code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/app/javascript/controllers/feature_controller.js
+++ b/app/javascript/controllers/feature_controller.js
@@ -135,7 +135,7 @@ export default class extends Controller {
   updateLineWidth () {
     const feature = this.getFeature()
     const size = document.querySelector('#line-width').value
-    document.querySelector('#line-width-val').innerHTML = '(' + size + ')'
+    document.querySelector('#line-width-val').textContent = '(' + size + ')'
     feature.properties['stroke-width'] = size
     // draw layer feature properties aren't getting updated by draw.set()
     draw.setFeatureProperty(this.featureIdValue, 'stroke-width', size)


### PR DESCRIPTION
Fixes [https://github.com/digitaltom/mapforge/security/code-scanning/2](https://github.com/digitaltom/mapforge/security/code-scanning/2)

To fix the problem, we need to ensure that any data inserted into the DOM as HTML is properly escaped to prevent XSS attacks. The best way to fix this issue is to use a method that safely sets text content rather than HTML content. In this case, we can use `textContent` instead of `innerHTML` to avoid interpreting the text as HTML.

- Change the assignment to `innerHTML` to use `textContent` instead.
- Specifically, update line 138 in `app/javascript/controllers/feature_controller.js` to use `textContent`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
