### PR TITLE
Fix code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/app/javascript/controllers/feature_edit_controller.js
+++ b/app/javascript/controllers/feature_edit_controller.js
@@ -53,7 +53,7 @@ export default class extends Controller {
   updatePointSize () {
     const feature = this.getFeature()
     const size = document.querySelector('#point-size').value
-    document.querySelector('#point-size-val').innerHTML = '(' + size + ')'
+    document.querySelector('#point-size-val').textContent = '(' + size + ')'
     feature.properties['marker-size'] = size
     // draw layer feature properties aren't getting updated by draw.set()
     draw.setFeatureProperty(this.featureIdValue, 'marker-size', size)


### PR DESCRIPTION
Fixes [https://github.com/digitaltom/mapforge/security/code-scanning/3](https://github.com/digitaltom/mapforge/security/code-scanning/3)

To fix the problem, we need to ensure that any user input is properly escaped before being inserted into the DOM as HTML. Instead of using `innerHTML`, which can interpret the input as HTML, we should use `textContent`, which treats the input as plain text and escapes any HTML characters.

- Change the assignment to `innerHTML` to `textContent` to prevent the interpretation of the input as HTML.
- Specifically, update line 56 in the file `app/javascript/controllers/feature_edit_controller.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
