### PR TITLE
allow to style overpass layers with comment params

### DIFF
--- a/app/javascript/maplibre/overpass/overpass.js
+++ b/app/javascript/maplibre/overpass/overpass.js
@@ -9,6 +9,7 @@ export function initializeOverpassLayers(id = null) {
   if (id) { initLayers = initLayers.filter(l => l.id === id)  }
   initLayers.forEach((layer) => {
     const clustered = layer.query.includes("cluster=true")
+    // TODO: changing cluster setup requires a map reload
     addGeoJSONSource('overpass-source-' + layer.id, clustered)
     initializeViewStyles('overpass-source-' + layer.id)
     if (clustered) {
@@ -39,7 +40,7 @@ export function loadOverpassLayer(id) {
     if (!query.includes("[timeout")) { query = "[timeout:25]" + query }
     if (!query.includes("[out")) { query = "[out:json]" + query }
   } else {
-    query = "[out:json][timeout:25][bbox:{{bbox}}];" + query
+    query = "[out:json][timeout:25][bbox:{{bbox}}];\n" + query
   }
   query = replaceBboxWithMapRectangle(query)
   console.log('Loading overpass layer', layer, query)

--- a/app/javascript/maplibre/overpass/overpass.js
+++ b/app/javascript/maplibre/overpass/overpass.js
@@ -1,5 +1,5 @@
 import { map, layers, redrawGeojson, addGeoJSONSource, viewUnchanged } from 'maplibre/map'
-import { applyOverpassQueryStyle, getQueryTemplate } from 'maplibre/overpass/queries'
+import { applyOverpassQueryStyle } from 'maplibre/overpass/queries'
 import { initializeViewStyles, initializeClusterStyles } from 'maplibre/styles'
 import * as functions from 'helpers/functions'
 import { initLayersModal } from 'maplibre/controls/shared'
@@ -8,11 +8,12 @@ export function initializeOverpassLayers(id = null) {
   let initLayers = layers.filter(l => l.type === 'overpass')
   if (id) { initLayers = initLayers.filter(l => l.id === id)  }
   initLayers.forEach((layer) => {
-    const clustered = !!getQueryTemplate(layer.name)?.cluster
+    const clustered = layer.query.includes("cluster=true")
     addGeoJSONSource('overpass-source-' + layer.id, clustered)
     initializeViewStyles('overpass-source-' + layer.id)
     if (clustered) {
-      initializeClusterStyles('overpass-source-' + layer.id, getQueryTemplate(layer.name).clusterIcon)
+      const clusterIcon = getCommentValue(layer.query, 'cluster-symbol')
+      initializeClusterStyles('overpass-source-' + layer.id, clusterIcon)
     }
     // use server's pre-loaded geojson if available and map is at default center
     if (layer.geojson?.features?.length && viewUnchanged()) { 
@@ -81,21 +82,22 @@ function applyOverpassStyle(geojson, query) {
   geojson.features.forEach( f => {
     f.properties["label"] = f.properties["name"]
     f.properties["desc"] = overpassDescription(f.properties)
-    if (query.includes("out skel")) { f.properties["heatmap"] = true }
-    if (f.properties['amenity'] === 'post_box') {
-      f.properties["marker-symbol"] = "📯"
+    if (query.includes("heatmap=true")) { f.properties["heatmap"] = true }
+    if (getCommentValue(query, 'marker-symbol')) {
+      f.properties["marker-symbol"] = getCommentValue(query, 'marker-symbol')
+      f.properties["marker-size"] = "20"
+      f.properties["marker-color"] = "transparent"
+      f.properties["stroke"] = "transparent"
     }
-
     // https://wiki.openstreetmap.org/wiki/Key:osmc:symbol?uselang=en
     // osmc:symbol=waycolor:background[:foreground][:foreground2][:text:textcolor]
     if ((f.geometry.type === 'LineString' || f.geometry.type === 'MultiLineString')
       && f.properties['osmc:symbol']) {
       const parts = f.properties['osmc:symbol'].split(':')
-
       f.properties["stroke"] = parts[0]
       f.properties["stroke-width"] = "2"
       f.properties["stroke-image-url"] = "/icon/osmc/" + f.properties['osmc:symbol']
-    // render 'ref' name as label on bike routes without osmc:symbol
+      // render 'ref' name as label on bike routes without osmc:symbol
     } else if (f.properties["route"] === 'bicycle' && f.properties["ref"]){
       f.properties["label"] = f.properties["ref"]
     }
@@ -115,4 +117,12 @@ function overpassDescription(props) {
   desc += '\n' + '[' + props['id'] + '](https://www.openstreetmap.org/' + props['id'] + ')'
 
   return desc
+}
+
+function getCommentValue(query, key) {
+  // Match lines like: // key=value (with possible spaces)
+  const regex = new RegExp(`^\\s*\\/\\/\\s*${key}\\s*=\\s*(.*)$`, "m")
+  const match = query.match(regex)
+
+  return match ? match[1].trim() : null
 }

--- a/app/javascript/maplibre/overpass/queries.js
+++ b/app/javascript/maplibre/overpass/queries.js
@@ -39,7 +39,6 @@ export const queries = [
         f.properties["stroke"] = "transparent"
       }
     },
-    cluster: true,
     clusterIcon: '/emojis/noto/🍻.png'
   },
   { name: 'Subway',

--- a/app/javascript/maplibre/overpass/queries.js
+++ b/app/javascript/maplibre/overpass/queries.js
@@ -12,16 +12,11 @@ export function applyOverpassQueryStyle (geojson, queryName) {
 
 export const queries = [
   { name: 'Public toilets',
-    query: "nwr[amenity=toilets];out center 250;",
-    style: (f) => {
-      if (['toilets'].includes(f.properties.amenity)) {
-         f.properties["marker-symbol"] = "🚻"
-         f.properties["marker-color"] = "transparent"
-      }
-  }},
+    query: "// marker-symbol=🚻\nnwr[amenity=toilets];out center 250;"
+  },
   // Brewery restaurants are tagged with microbrewery=yes (https://wiki.openstreetmap.org/wiki/Brewery)
   { name: 'Breweries',
-    query: '(nwr["craft"~"brewery",i];nwr["microbrewery"="yes"];nwr["industrial"="brewery"];);out center 250;',
+    query: '// cluster-symbol=🍻\n(nwr["craft"~"brewery",i];nwr["microbrewery"="yes"];nwr["industrial"="brewery"];);out center 250;',
     style: (f) => {
       if (f.properties?.microbrewery === 'yes') {
         f.properties["marker-symbol"] = "🍻"
@@ -38,8 +33,7 @@ export const queries = [
         f.properties["marker-color"] = "transparent"
         f.properties["stroke"] = "transparent"
       }
-    },
-    clusterIcon: '/emojis/noto/🍻.png'
+    }
   },
   { name: 'Subway',
     query: '(relation["railway"="subway"];way["railway"="subway"];); \n' +
@@ -55,16 +49,10 @@ export const queries = [
       }
   }},
   { name: 'Drinking water',
-    query: "nwr[amenity=drinking_water];out center 250;",
-    style: (f) => {
-      if (f.properties.amenity === 'drinking_water') {
-         f.properties["marker-symbol"] = "🚰"
-         f.properties["marker-color"] = "transparent"
-         f.properties["stroke"] = "transparent"
-      }
-    },
-    cluster: true,
-    clusterIcon: '/emojis/noto/🚰.png'
+    query: '// marker-symbol=🚰\n' +
+      '// cluster=true\n' +
+      '// cluster-symbol=🚰\n' +
+      'nwr[amenity=drinking_water];out center 250;'
   },
   { name: 'Hiking routes',
     query: "relation[type=route][route=hiking];out geom 75;",
@@ -80,37 +68,28 @@ export const queries = [
     query: "relation[type=route][route=bicycle];out geom 75;",
   },
   { name: 'Camping',
-    query: "nwr[tourism=camp_site];out center;",
-    style: (f) => {
-      if (f.properties.tourism === 'camp_site') {
-        f.properties["marker-symbol"] = "🏕️"
-      }
-    }, 
-    cluster: true,
-    clusterIcon: '/emojis/noto/🏕️.png'
+    query: '// marker-symbol=🏕️\n' + 
+      '// cluster=true\n' +
+      '// cluster-symbol=🏕️\n' +
+      'nwr[tourism=camp_site];out center;'
   },
   { name: 'Feuerwehr',
-    query: "nwr[amenity=fire_station];\nout center 500;",
-    style: (f) => {
-      if (['fire_station'].includes(f.properties['amenity'])) {
-        f.properties["marker-symbol"] = "🚒"
-        f.properties["marker-color"] = "#fff"
-      }
-    },
-    cluster: true,
-    clusterIcon: '/emojis/noto/🚒.png',
+    query: '// marker-symbol=🚒\n' +
+      '// cluster=true\n' +
+      '// cluster-symbol=🚒\n' +
+      'nwr[amenity=fire_station];\nout center 500;'
   },
   {
     name: 'Hydranten',
-    query: 'node["emergency"="fire_hydrant"];\nout body 1000;',
+    query: '// cluster=true\n' +
+      '// cluster-symbol=🌊\n' +
+      'node["emergency"="fire_hydrant"];\nout body 1000;',
     style: (f) => {
       if (['fire_hydrant'].includes(f.properties['emergency'])) {
         f.properties["marker-symbol"] = "🌊"
         f.properties["marker-color"] = "#fff"
       }
-    },
-    cluster: true,
-    clusterIcon: '/emojis/noto/🌊.png',
+    }
   },  
   { name: 'Trains',
     query: '(relation["route"="tracks"]; // Train tracks (railways)\n' +
@@ -143,11 +122,13 @@ export const queries = [
     }
   },
   { name: 'Food Shops',
-    query: '(nwr[shop=supermarket];\n' +
-           'nwr[amenity=fuel][shop=yes];\n' +
-           'nwr[shop=bakery];\n' +
-           // 'nwr[shop=butcher];\n' +
-           ');out center 250;',
+    query: '// cluster=true\n' +
+      '// cluster-symbol=🥨\n' +
+      '(nwr[shop=supermarket];\n' +
+      'nwr[amenity=fuel][shop=yes];\n' +
+      'nwr[shop=bakery];\n' +
+      // 'nwr[shop=butcher];\n' +
+      ');out center 250;',
     style: (f) => {
       if (['supermarket'].includes(f.properties['shop'])) {
         f.properties["marker-symbol"] = "🛒"
@@ -162,13 +143,13 @@ export const queries = [
       if (['butcher'].includes(f.properties['shop'])) {
         f.properties["marker-symbol"] = "🥩"
       }
-    },
-    cluster: true,
-    clusterIcon: '/emojis/noto/🥨.png'
+    }
   },
   {
     name: 'Swimming pools 🏊',
-    query: 'nwr[leisure = water_park];\n' +
+    query: '// cluster=true\n' +
+      '// cluster-symbol=🏊\n' +
+      'nwr[leisure = water_park];\n' +
       'out center 250;\n' +
       'nwr[leisure = water_park];\n' +
       'out geom 250;',
@@ -180,8 +161,6 @@ export const queries = [
       if (f.geometry.type === 'Polygon') {
         f.properties["label"] = ""
       }
-    },
-    cluster: false,
-    clusterIcon: '/emojis/noto/🏊.png'
+    }
   }
 ]

--- a/app/javascript/maplibre/styles.js
+++ b/app/javascript/maplibre/styles.js
@@ -377,9 +377,9 @@ export function styles () {
         ["has", "heatmap"],
         ["has", "user_heatmap"]],
       paint: {
-        'heatmap-opacity': 0.8,
-        'heatmap-intensity': 1,
-        'heatmap-radius': 10
+        'heatmap-opacity': 0.7,
+        'heatmap-intensity': 1.3,
+        'heatmap-radius': 17
       }
     },
     // background + border for symbols
@@ -533,7 +533,7 @@ export function clusterStyles(icon) {
       type: 'symbol',
       filter: ['has', 'point_count'],
       layout: {
-        'icon-image': icon || '',
+        'icon-image': (icon ? '/emojis/noto/' + icon + '.png' : ''),
         'icon-size': 0.5,
         'icon-overlap': 'always'
       }

--- a/docs/overpass.md
+++ b/docs/overpass.md
@@ -4,10 +4,10 @@ Mapforge supports adding layers defined by Overpass queries.
 There are a couple of pre-defined queries available to add to your map, 
 or you can define a custom query. 
 
-The look of query results can get customized by adding one or more of these 
+The look of query results can be customized by adding one or more of these 
 settings as comments to the query: 
 
-`// heatmap=true` - Results will get rendered as a heat map 
-`// point-symbol=🍻` - Nodes/points will use this symbol (emoji)
-`// cluster=true` - Results will get clustered when too many results are close to each other
+`// heatmap=true` - Results will be rendered as a heat map 
+`// marker-symbol=🍻` - Nodes/points will use this symbol (emoji)
+`// cluster=true` - Results will be clustered when too many results are close to each other
 `// cluster-symbol=🍻` - Emoji/icon path used for clusters 

--- a/docs/overpass.md
+++ b/docs/overpass.md
@@ -1,0 +1,13 @@
+# Overpass queries 
+
+Mapforge supports adding layers defined by Overpass queries. 
+There are a couple of pre-defined queries available to add to your map, 
+or you can define a custom query. 
+
+The look of query results can get customized by adding one or more of these 
+settings as comments to the query: 
+
+`// heatmap=true` - Results will get rendered as a heat map 
+`// point-symbol=🍻` - Nodes/points will use this symbol (emoji)
+`// cluster=true` - Results will get clustered when too many results are close to each other
+`// cluster-symbol=🍻` - Emoji/icon path used for clusters 


### PR DESCRIPTION
## Summary by Sourcery

Enable flexible styling of Overpass layers by parsing comment directives in query strings, update default heatmap and cluster icon styles, and document the new configuration options.

New Features:
- Enable inline comment-based styling of Overpass layers for heatmaps, point symbols, and cluster symbols

Enhancements:
- Detect clustering, marker-symbol, and heatmap parameters directly from query comments instead of static templates
- Introduce getCommentValue helper to extract key=value styling directives from query text
- Adjust default heatmap paint properties (opacity, intensity, radius) for improved visualization
- Prefix cluster symbol icon paths with '/emojis/noto/' when provided

Documentation:
- Add documentation for Overpass query comment styling options