### PR TITLE
improve mobile nav menu

### DIFF
--- a/app/assets/stylesheets/header.css
+++ b/app/assets/stylesheets/header.css
@@ -1,5 +1,5 @@
 .navbar {
-  opacity: 0.9;
+  opacity: 1;
   z-index: 10;
 }
 

--- a/app/assets/stylesheets/map.css
+++ b/app/assets/stylesheets/map.css
@@ -3,7 +3,7 @@ html:has(.map), body:has(.map) {
   overflow: hidden;
 }
 
-#map-header {
+nav {
   display: none;
 }
 

--- a/app/assets/stylesheets/map.css
+++ b/app/assets/stylesheets/map.css
@@ -1,10 +1,10 @@
 /* this avoids mobile to scroll vertically out the location bar */
 html:has(.map), body:has(.map) {
   overflow: hidden;
-}
 
-nav {
-  display: none;
+  #map-header nav {
+    display: none;
+  }
 }
 
 #map-head {
@@ -21,8 +21,10 @@ nav {
   cursor: pointer;
   background: #fffa;
   border-radius: 3px;
-  box-shadow: 0 0 0 2px #BBB;
-  margin-top: 0.2em;
+  box-shadow: 0 0 0 1.5px #BBB;
+  margin-top: 0.75em;
+
+  --bs-navbar-toggler-icon-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%2833, 37, 41, 0.75%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
 }
 
 #map-title {
@@ -73,7 +75,7 @@ nav {
 }
 
 #map-nav-toggle {
-  font-size: 1.3em;
+  font-size: 0.8em;
   cursor: pointer;
 }
 

--- a/app/javascript/controllers/header_controller.js
+++ b/app/javascript/controllers/header_controller.js
@@ -7,12 +7,12 @@ export default class extends Controller {
   }
 
   hideNavBar (_event) {
-    functions.e('nav', e => { e.style.display = 'none' })
+    functions.e('#map-header nav', e => { e.style.display = 'none' })
   }
 
   showNavBar (_event) {
     resetControls()
-    functions.e('nav', e => { e.style.display = 'block' })
+    functions.e('#map-header nav', e => { e.style.display = 'block' })
   }  
 
   hideNavDropdown (event) {
@@ -37,8 +37,12 @@ export default class extends Controller {
       this.showNavBar(event)
       this.showNavDropdown(event)
     } else {
-      if (document.querySelector('.map')) { let controller = this; setTimeout(function () { controller.hideNavBar(event) }, 300) }
-      this.hideNavDropdown(event)
+      this.hideNav (event)
     }
   }
+
+  hideNav (_event) {
+    if (document.querySelector('.map')) { let controller = this; setTimeout(function () { controller.hideNavBar(event) }, 300) }
+    this.hideNavDropdown(event)
+  }  
 }

--- a/app/javascript/controllers/header_controller.js
+++ b/app/javascript/controllers/header_controller.js
@@ -1,0 +1,44 @@
+import { Controller } from '@hotwired/stimulus'
+import * as functions from 'helpers/functions'
+import { resetControls } from 'maplibre/controls/shared'
+
+export default class extends Controller {
+  connect () {
+  }
+
+  hideNavBar (_event) {
+    functions.e('nav', e => { e.style.display = 'none' })
+  }
+
+  showNavBar (_event) {
+    resetControls()
+    functions.e('nav', e => { e.style.display = 'block' })
+  }  
+
+  hideNavDropdown (event) {
+    functions.e('.navbar-collapse.show', e => {
+      let bsCollapse = new bootstrap.Collapse(e)
+      bsCollapse.hide()
+      // prevent default click handling on page when collapsing nav dropdown
+      event.preventDefault()
+    })
+  }
+
+  showNavDropdown (_event) {
+    functions.e('.navbar-collapse', e => {
+      let bsCollapse = new bootstrap.Collapse(e)
+      bsCollapse.show()
+    })
+  }
+
+  // Toggle Navbar + Dropdown on map page, only dropdown on other pages
+  toggleNav (event) {
+    if (!document.querySelector('#navbar-dropdown.show')) {
+      this.showNavBar(event)
+      this.showNavDropdown(event)
+    } else {
+      if (document.querySelector('.map')) { let controller = this; setTimeout(function () { controller.hideNavBar(event) }, 300) }
+      this.hideNavDropdown(event)
+    }
+  }
+}

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -1,14 +1,12 @@
 import { Controller } from '@hotwired/stimulus'
 import * as functions from 'helpers/functions'
-import { animateElement } from 'helpers/dom'
 import { initializeMap, setBackgroundMapLayer, initializeViewMode, initializeStaticMode } from 'maplibre/map'
 import { initializeEditMode } from 'maplibre/edit'
 import { initializeSocket } from 'channels/map_channel'
-import { resetControls } from 'maplibre/controls/shared'
 
 export default class extends Controller {
   connect () {
-    functions.e('#map-header', e => { e.style.display = 'none' })
+    functions.e('nav', e => { e.style.display = 'none' })
     initializeMap('maplibre-map')
     // static mode is used for screenshots + frontpage
     if (window.gon.map_mode === 'static') {
@@ -18,29 +16,5 @@ export default class extends Controller {
       window.gon.map_mode !== 'rw' ? initializeViewMode() : initializeEditMode()
     }
     setBackgroundMapLayer()
-  }
-
-  toggleNavigation (_event) {
-    if (document.querySelector('#map-header').style.display === 'none') {
-      functions.e('#map-header', e => { e.style.display = 'block' })
-      resetControls()
-      functions.e('#map-nav-toggle', e => {
-        e.classList.remove('bi-caret-down')
-        e.classList.add('bi-caret-up')
-      })
-      functions.e('#map-head', e => { e.style.top = '60px' })
-      functions.e('.maplibregl-ctrl-top-left', e => { e.style.top = '60px' })
-      functions.e('.maplibregl-ctrl-top-right', e => { e.style.top = '60px' })
-      animateElement('.navbar', 'fade-down')
-    } else {
-      functions.e('#map-header', e => { e.style.display = 'none' })
-      functions.e('#map-nav-toggle', e => {
-        e.classList.remove('bi-caret-up')
-        e.classList.add('bi-caret-down')
-      })
-      functions.e('#map-head', e => { e.style.top = 'unset' })
-      functions.e('.maplibregl-ctrl-top-left', e => { e.style.top = '2.4em' })
-      functions.e('.maplibregl-ctrl-top-right', e => { e.style.top = 'unset' })
-    }
   }
 }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -6,7 +6,7 @@ import { initializeSocket } from 'channels/map_channel'
 
 export default class extends Controller {
   connect () {
-    functions.e('nav', e => { e.style.display = 'none' })
+    functions.e('#map-header nav', e => { e.style.display = 'none' })
     initializeMap('maplibre-map')
     // static mode is used for screenshots + frontpage
     if (window.gon.map_mode === 'static') {

--- a/app/views/frontpage/index.haml
+++ b/app/views/frontpage/index.haml
@@ -1,5 +1,4 @@
-%main#frontpage.main{ data: { 'controller': "frontpage" } }
-
+%main#frontpage.main{ data: { 'controller': "frontpage header", 'action': "click->header#hideNavDropdown" } }
   / Hero Section
   #hero.hero.section.dark-background
     = image_tag "frontpage/background_map3.jpg", alt: "", 'data-aos': "zoom-out", 'data-aos-once': "true"

--- a/app/views/maps/index.html.haml
+++ b/app/views/maps/index.html.haml
@@ -1,8 +1,8 @@
-- content_for :title, "Mapforge: Explore maps"
+- content_for :title, "Mapforge: Browse maps"
 
 = turbo_stream_from "public_maps_list"
 
-#maps.flex-container.flex-center
+#maps.flex-container.flex-center{ data: { 'controller': "header", 'action': "click->header#hideNavDropdown" } }
   - @maps.each do |map|
     = render map, rw: false, last_change: false, avatar: false, delete: false
 

--- a/app/views/maps/maplibre.haml
+++ b/app/views/maps/maplibre.haml
@@ -25,11 +25,11 @@
 #preloader
   %img.mapforge-logo{ src: "/icons/mapforge-logo-header_white.png", alt: "Logo" }
 
-#map-head.dark-shadow{ title: "Toggle Navigation", data: { 'controller': "map header", 'action': "click->header#toggleNav", 'toggle': "tooltip", 'bs-placement': "bottom", 'bs-custom-class': 'maplibregl-ctrl-tooltip' } }
+%nav#map-head.dark-shadow{ title: "Toggle Navigation", data: { 'controller': "map header", 'action': "click->header#toggleNav", 'toggle': "tooltip", 'bs-placement': "bottom", 'bs-custom-class': 'maplibregl-ctrl-tooltip' } }
   #map-nav-toggle.navbar-toggler-icon.ms-2.me-2
   #map-title
 
-#maplibre-map.map{ data: { 'controller': "header", 'action': "click->header#hideNavDropdown" } }
+#maplibre-map.map{ data: { 'controller': "header", 'action': "click->header#hideNav" } }
 
 - unless @map_mode == 'static'
   = render 'status'

--- a/app/views/maps/maplibre.haml
+++ b/app/views/maps/maplibre.haml
@@ -25,11 +25,11 @@
 #preloader
   %img.mapforge-logo{ src: "/icons/mapforge-logo-header_white.png", alt: "Logo" }
 
-#map-head.dark-shadow{ title: "Toggle Navigation", data: { 'controller': "map", 'action': "click->map#toggleNavigation", 'toggle': "tooltip", 'bs-placement': "bottom", 'bs-custom-class': 'maplibregl-ctrl-tooltip' } }
-  %i#map-nav-toggle.bi.bi-caret-down.ms-2.me-2
+#map-head.dark-shadow{ title: "Toggle Navigation", data: { 'controller': "map header", 'action': "click->header#toggleNav", 'toggle': "tooltip", 'bs-placement': "bottom", 'bs-custom-class': 'maplibregl-ctrl-tooltip' } }
+  #map-nav-toggle.navbar-toggler-icon.ms-2.me-2
   #map-title
 
-#maplibre-map.map
+#maplibre-map.map{ data: { 'controller': "header", 'action': "click->header#hideNavDropdown" } }
 
 - unless @map_mode == 'static'
   = render 'status'

--- a/app/views/maps/my.haml
+++ b/app/views/maps/my.haml
@@ -1,6 +1,6 @@
 - content_for :title, "Mapforge: My maps"
 
-#maps.flex-container.flex-center
+#maps.flex-container.flex-center{ data: { 'controller': "header", 'action': "click->header#hideNavDropdown" } }
   - @maps.each do |map|
     = render map, rw: true, last_change: false, avatar: false, delete: true
 

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -1,4 +1,4 @@
-%footer#footer.footer.light-background
+%footer#footer.footer.light-background{ data: { 'controller': "header", 'action': "click->header#hideNavDropdown" } }
   .footer-top
     .container
       .row.gy-4

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -4,11 +4,11 @@
       %img.mapforge-logo{ src: "/icons/mapforge-logo-header_white.png", alt: "Logo" }
       .mapforge-font.white-shadow.d-none.d-sm-block{ href: "#" } Mapforge
 
-    %button.navbar-toggler{ type: "button", "data-bs-toggle": "collapse", "data-bs-target": "#navbarSupportedContent", "aria-controls": "navbarSupportedContent", "aria-expanded": "false", "aria-label": "Toggle navigation" }
+    %button.navbar-toggler{ data: { 'controller': "header", 'action': "click->header#toggleNav" }, type: "button", "aria-controls": "navbar-dropdown", "aria-expanded": "false", "aria-label": "Toggle navigation" }
       %span.navbar-toggler-icon
 
     - # Desktop (>=sm, 574px)
-    #navbarSupportedContent.collapse.navbar-collapse.d-none.d-sm-block
+    .d-none.d-sm-block
       %ul.navbar-nav.me-auto.mb-0.mt-1
         - if menu
           %li.nav-item
@@ -21,7 +21,7 @@
           Create map
 
     - # Mobile (<sm, 574px)
-    #navbarSupportedContent.collapse.navbar-collapse
+    #navbar-dropdown.collapse.navbar-collapse
       %ul.navbar-nav.me-auto.mb-0.mt-1.d-sm-none
         - if menu
           %li.nav-item
@@ -59,7 +59,7 @@
       .dropdown.profile-dropdown
 
         - # Mobile (<sm, 574px)
-        %a.d-sm-none{ type: "button", "data-bs-toggle": "collapse", "data-bs-target": "#navbarSupportedContent", "aria-controls": "navbarSupportedContent", "aria-expanded": "false", "aria-label": "Toggle navigation" }
+        %a.d-sm-none{ type: "button", "data-bs-toggle": "collapse", "data-bs-target": "#navbar-dropdown", "aria-controls": "navbar-dropdown", "aria-expanded": "false", "aria-label": "Toggle navigation" }
           - if @user.image
             %img.profile-image{ src: @user.image, alt: '', title: @user.email }
           - else


### PR DESCRIPTION
## Summary by Sourcery

Overhaul the mobile navigation by replacing custom map-based toggle logic with a dedicated Stimulus `header` controller, updating view templates to use Bootstrap collapse on `#navbar-dropdown`, adding hide-on-click behaviour across pages, and adjusting CSS and page titles accordingly.

Enhancements:
- Migrate mobile nav toggle from the map controller to a Stimulus `header` controller.
- Update the header partial to collapse the mobile menu using `#navbar-dropdown` and attach `click->header#toggleNav` actions.
- Add `click->header#hideNavDropdown` actions to main containers in map, frontpage, and footer views to auto-hide the dropdown when interacting with the page.
- Adjust styling by changing the hidden selector from `#map-header` to `nav` in CSS.
- Rename page title from “Explore maps” to “Browse maps” in the maps index view.