### PR TITLE
Potential fix for code scanning alert no. 7: CSRF protection weakened or disabled

### DIFF
--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -9,7 +9,6 @@ class MapsController < ApplicationController
 
   skip_before_action :set_user, only: %i[catchall]
   # site is cookie less for anonymous users, so no csrf token is set
-  skip_before_action :verify_authenticity_token, only: %i[show properties feature], unless: :set_user
 
   layout "map", only: [ :show ]
 


### PR DESCRIPTION
Potential fix for [https://github.com/mapforge-org/mapforge/security/code-scanning/7](https://github.com/mapforge-org/mapforge/security/code-scanning/7)

To fix the problem, CSRF protection should not be disabled for the `show`, `properties`, and `feature` actions. The best way to address this is to remove the line that skips CSRF verification for these actions. This will ensure that Rails' default CSRF protection is applied, mitigating the risk of CSRF attacks. If there is a legitimate reason to disable CSRF protection for truly stateless, read-only, and public endpoints, it should be done with extreme caution and only after a thorough security review. In this case, since the actions appear to be read-only, but the risk of future changes or misconfiguration exists, it is safer to keep CSRF protection enabled.

**What to change:**  
- Remove or comment out the line:  
  `skip_before_action :verify_authenticity_token, only: %i[show properties feature], unless: :set_user`  
  in `app/controllers/maps_controller.rb`.

No additional imports or method definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Re-enable Rails CSRF verification for show, properties, and feature endpoints to mitigate potential CSRF vulnerabilities