### PR TITLE
Revert "[ruby] Update thruster 0.1.15 → 0.1.16 (minor)"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -566,7 +566,7 @@ GEM
     temple (0.10.4)
     thor (1.4.0)
     thread_safe (0.3.6)
-    thruster (0.1.16-x86_64-linux)
+    thruster (0.1.15-x86_64-linux)
     tilt (2.6.1)
     timeout (0.4.3)
     tsort (0.2.0)


### PR DESCRIPTION
Reverts mapforge-org/mapforge#497